### PR TITLE
Added missing comma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         'ase',
         'networkx',
         'rmsd'
-    ]
+    ],
     author="Judit Zador, Ruben Van de Vijver, Carles Marti, Amanda Dewyer",
     author_email = "jzador@sandia.gov",
     description = "Automated reaction kinetics for gas-phase species",


### PR DESCRIPTION
This leads to SyntaxError: invalid syntax when running setup.py. I have several examples for this behaviour.